### PR TITLE
Add cross-platform cmake support, including zlib detection.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -62,3 +62,17 @@ The header file's under the "include" directory, and the source file is under th
 You'll probably end up recompiling them a lot though :(
 
 And they'll be optimized (or not) the same way the rest of your project is optimized :(
+
+BUILDING CROSS-PLATFORM
+=======================
+
+CMake support is included in the "cmake" directory. You will need to have zlib installed on your development platform.
+
+To build on a *NIX the first time:
+
+1. Go to the project root.
+2. mkdir build (to create a build directory)
+3. cd build (enter the directory)
+4. cmake -g"Unix Makefiles" ../cmake
+
+Once that is done, simply type "make" inside your "build" folder. The will build the rexspeeder library for your platform. You can then copy it to your project's dependencies folder, link to it with -lrexspeeder (or equivalent), and include REXSpeeder.h. Alternatively, include this as a target in your cmake file.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -19,3 +19,9 @@ if (ZLIB_FOUND)
 	include_directories(${ZLIB_INCLUDE_DIRS})
 	target_link_libraries(rexspeeder ${ZLIB_LIBRARIES})
 endif()
+
+# Create a symlink to the files needed for example
+add_custom_command(
+    TARGET rexspeeder POST_BUILD
+    COMMAND ln -sf ../example/files .
+)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1)
+project("REXSpeeder")
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+add_library(rexspeeder ../src/REXSpeeder.cpp)
+add_executable(example ../example/example.cpp)
+target_link_libraries(example rexspeeder)
+
+# Include the "include" folder for headers
+target_include_directories(rexspeeder PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+)
+
+# We depend upon zlib
+find_package(ZLIB REQUIRED)
+if (ZLIB_FOUND)
+	include_directories(${ZLIB_INCLUDE_DIRS})
+	target_link_libraries(rexspeeder ${ZLIB_LIBRARIES})
+endif()

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -6,7 +6,7 @@ void testTime(std::string fname);
 
 int main() {
 	try {
-		xp::RexImage nyan("files\\nyan.xp");
+		xp::RexImage nyan("files/nyan.xp");
 
 		/*Flatten all layers into one, respecting transparency.*/
 		nyan.flatten();


### PR DESCRIPTION
This pull request:
- Adds a CMakeFiles.txt file to the new "cmake" folder. It supports zlib detection.
- Adds instructions for a cmake build on *NIX (tested on OS X and Linux) to the INSTALL file.
- Modifies the path to `nyan.xp` in `example.cpp` to use a forward slash. Forward slashes work on Windows, too!

It doesn't make any additional changes to your code-base - just adds Linux and OS X support. Let me know if there's anything you'd like changed.
