### PR TITLE
Apply idiomatic C++11

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -62,3 +62,17 @@ The header file's under the "include" directory, and the source file is under th
 You'll probably end up recompiling them a lot though :(
 
 And they'll be optimized (or not) the same way the rest of your project is optimized :(
+
+BUILDING CROSS-PLATFORM
+=======================
+
+CMake support is included in the "cmake" directory. You will need to have zlib installed on your development platform.
+
+To build on a *NIX the first time:
+
+1. Go to the project root.
+2. mkdir build (to create a build directory)
+3. cd build (enter the directory)
+4. cmake -g"Unix Makefiles" ../cmake
+
+Once that is done, simply type "make" inside your "build" folder. The will build the rexspeeder library for your platform. You can then copy it to your project's dependencies folder, link to it with -lrexspeeder (or equivalent), and include REXSpeeder.h. Alternatively, include this as a target in your cmake file.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1)
+project("REXSpeeder")
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+add_library(rexspeeder ../src/REXSpeeder.cpp)
+add_executable(example ../example/example.cpp)
+target_link_libraries(example rexspeeder)
+
+# Include the "include" folder for headers
+target_include_directories(rexspeeder PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+)
+
+# We depend upon zlib
+find_package(ZLIB REQUIRED)
+if (ZLIB_FOUND)
+	include_directories(${ZLIB_INCLUDE_DIRS})
+	target_link_libraries(rexspeeder ${ZLIB_LIBRARIES})
+endif()

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -6,7 +6,7 @@ void testTime(std::string fname);
 
 int main() {
 	try {
-		xp::RexImage nyan("files\\nyan.xp");
+		xp::RexImage nyan("files/nyan.xp");
 
 		/*Flatten all layers into one, respecting transparency.*/
 		nyan.flatten();

--- a/include/REXSpeeder.h
+++ b/include/REXSpeeder.h
@@ -28,7 +28,10 @@ namespace xp {
 	inline bool isTransparent(RexTile* tile);
 
 	//Returns a transparent tile.
-	inline RexTile transparentTile();
+	inline RexTile transparentTile()
+	{
+		return RexTile{0, 0, 0, 0, 255, 255, 0};
+	}
 
 	struct RexLayer {
 		RexTile* tiles;

--- a/include/REXSpeeder.h
+++ b/include/REXSpeeder.h
@@ -3,10 +3,10 @@
 #include <iostream>
 
 //There is a maximum of four layers in an .xp file
-#define REXPAINT_MAX_NUM_LAYERS 4
+constexpr int REXPAINT_MAX_NUM_LAYERS=4;
 
 //The error code thrown when a file does not exist. Strangely, gzopen does not set an error code.
-#define REXSPEEDER_FILE_DOES_NOT_EXIST 20202
+constexpr int REXSPEEDER_FILE_DOES_NOT_EXIST=20202;
 
 namespace xp {
 	//This struct matches the order and width of data in .xp tiles.

--- a/include/REXSpeeder.h
+++ b/include/REXSpeeder.h
@@ -1,8 +1,7 @@
 /*For version 1.02 of REXPaint*/
-
-#ifndef REXSPEEDER_H
-#define REXSPEEDER_H
+#pragma once
 #include <iostream>
+
 //There is a maximum of four layers in an .xp file
 #define REXPAINT_MAX_NUM_LAYERS 4
 
@@ -101,4 +100,3 @@ namespace xp {
 		std::string err;
 	};
 }
-#endif //REXSPEEDER_H

--- a/include/REXSpeeder.h
+++ b/include/REXSpeeder.h
@@ -1,6 +1,7 @@
 /*For version 1.02 of REXPaint*/
 #pragma once
 #include <iostream>
+#include <stdint.h>
 
 //There is a maximum of four layers in an .xp file
 constexpr int REXPAINT_MAX_NUM_LAYERS=4;
@@ -12,13 +13,13 @@ namespace xp {
 	//This struct matches the order and width of data in .xp tiles.
 	struct  RexTile {
 		//I don't know why a CP437 character should be 4 bytes wide, but thus sprach the manual.
-		unsigned int  character;
-		unsigned char fore_red;
-		unsigned char fore_green;
-		unsigned char fore_blue;
-		unsigned char back_red;
-		unsigned char back_green;
-		unsigned char back_blue;
+		uint32_t  character;
+		uint8_t fore_red;
+		uint8_t fore_green;
+		uint8_t fore_blue;
+		uint8_t back_red;
+		uint8_t back_green;
+		uint8_t back_blue;
 	};
 
 	//REXpaint identifies transparent tiles by setting their background color to 255,0,255.

--- a/include/REXSpeeder.h
+++ b/include/REXSpeeder.h
@@ -2,6 +2,8 @@
 #pragma once
 #include <iostream>
 #include <stdint.h>
+#include <array>
+#include <vector>
 
 //There is a maximum of four layers in an .xp file
 constexpr int REXPAINT_MAX_NUM_LAYERS=4;
@@ -34,8 +36,9 @@ namespace xp {
 	}
 
 	struct RexLayer {
-		RexTile* tiles;
+		std::vector<RexTile> tiles;
 		RexLayer(int width, int height);
+		RexLayer() {}
 		~RexLayer();
 	};
 
@@ -65,11 +68,11 @@ namespace xp {
 
 		//Returns a pointer to a single tile specified by layer, x coordinate, y coordinate.
 		//0,0 is the top-left corner.
-		inline RexTile* getTile(int layer, int x, int y) { return &layers[layer]->tiles[y + (x * height)]; };
+		inline RexTile* getTile(int layer, int x, int y) { return &layers[layer].tiles[y + (x * height)]; };
 
 		//Returns a pointer to a single tile specified by layer and the actual index into the array.
 		//Useful for iterating through a whole layer in one go for coordinate-nonspecific tasks.
-		inline RexTile* getTile(int layer, int index) { return &layers[layer]->tiles[index]; };
+		inline RexTile* getTile(int layer, int index) { return &layers[layer].tiles[index]; };
 
 		//Replaces the data for a tile. Not super necessary, but might save you a couple lines.
 		inline void setTile(int layer, int x, int y, RexTile& val) { *getTile(layer, x, y) = val; };
@@ -81,12 +84,11 @@ namespace xp {
 		//Respects transparency.
 		void flatten();
 
-		~RexImage();
 	private:
 		//Image properties
 		int version;
 		int width, height, num_layers;
-		RexLayer* layers[REXPAINT_MAX_NUM_LAYERS]; //layers[0] is the first layer.
+		std::array<RexLayer, REXPAINT_MAX_NUM_LAYERS> layers; //layers[0] is the first layer.
 
 		//Forbid default construction.
 		RexImage();

--- a/src/REXSpeeder.cpp
+++ b/src/REXSpeeder.cpp
@@ -1,5 +1,5 @@
 #include "REXSpeeder.h"
-#include "zlib.h"
+#include <zlib.h>
 
 //===========================================================================================================//
 //    Safe I/O (where "safe" means "will throw errors")                                                      //

--- a/src/REXSpeeder.cpp
+++ b/src/REXSpeeder.cpp
@@ -74,7 +74,7 @@ namespace xp {
 			s_gzread(gz, (vp)&height, sizeof(height));
 
 			for (int i = 0; i < num_layers; i++)
-				layers[i] = new RexLayer(width, height);
+				layers[i] = RexLayer(width, height);
 
 			for (int layer_index = 0; layer_index < num_layers; layer_index++) {
 				for (int i = 0; i < width*height; ++i)
@@ -128,22 +128,12 @@ namespace xp {
 	RexImage::RexImage(int _version, int _width, int _height, int _num_layers)
 		:version(_version), width(_width), height(_height), num_layers(_num_layers)
 	{
-		for (int i = 0; i < num_layers; i++)
-			layers[i] = new RexLayer(width, height);
-
 		//All layers above the first are set transparent.
 		for (int l = 1; l < num_layers; l++) {
 			for (int i = 0; i < width*height; ++i) {
 				RexTile t = transparentTile();
 				setTile(l, i, t);
 			}
-		}
-	}
-
-	RexImage::~RexImage() 
-	{
-		for (int i = 0; i < num_layers; i++) {
-			delete(layers[i]);
 		}
 	}
 
@@ -163,7 +153,6 @@ namespace xp {
 		}
 
 		//Remove the last layer
-		delete(layers[num_layers - 1]);
 		--num_layers;
 
 		//Recurse
@@ -180,11 +169,13 @@ namespace xp {
 //    RexLayer constructor/destructor                                                                        //
 //===========================================================================================================//
 
-	RexLayer::RexLayer(int width, int height) :tiles(new RexTile[width*height]) {} 
+	RexLayer::RexLayer(int width, int height) 
+	{
+		tiles.resize(width * height);
+	} 
 
 	RexLayer::~RexLayer()
 	{
-			delete[] tiles;
-			tiles = nullptr;
+		tiles.clear();
 	}
 }

--- a/src/REXSpeeder.cpp
+++ b/src/REXSpeeder.cpp
@@ -174,16 +174,7 @@ namespace xp {
 	bool isTransparent(RexTile * tile)
 	{
 		return (tile->back_red == 255 && tile->back_green == 0 && tile->back_blue == 255);
-	}
-
-	RexTile transparentTile()
-	{
-		RexTile t;
-		t.back_red = 255;
-		t.back_blue = 255;
-		t.back_green = 0;
-		return t;
-	}
+	}	
 
 //===========================================================================================================//
 //    RexLayer constructor/destructor                                                                        //


### PR DESCRIPTION
Not sure if you want this or not, but this is some clean-up I did to move to a more idiomatic C++11 style:
- Use `#pragma once` for the include guard. I've yet to find a compiler that doesn't support this.
- Switch `#define` constants to use `constexpr`. This is a matter of taste, but when I can avoid the pre-processor I do so.
- Use `stdint` and switch `unsigned char` to `uint8_t` and `unsigned int` to `int32_t`. This preserves your intent (and file compatibility) even if someone compiles on a platform in which int is not 32-bits.
- `transparentTile()` wasn't really inlined, because it was in the body - unless you had Whole Program Optimization enabled (which you generally don't on non-Windows platforms by default). I also used an initializer list to simplify it.
- Angle brackets for library includes; on most platforms it doesn't matter, but you never know...
- Replace the old-style arrays utilizing `new` and `delete` with `std::array` and `std::vector` from the STL. This removes any responsibility for cleaning up memory from the program.
- My testing showed that it was ridiculously fast before these changes, and is still ridiculously fast. :-)
